### PR TITLE
Add Acid style

### DIFF
--- a/replacements/openrct2.music.acid/object.json
+++ b/replacements/openrct2.music.acid/object.json
@@ -1,0 +1,22 @@
+{
+    "id": "openrct2.music.acid",
+    "sourceGame": "official",
+    "authors": [
+        "Karst van Galen Last"
+    ],
+    "version": "1.0",
+    "objectType": "music",
+    "properties": {
+        "tracks": [
+            {
+                "source": "music/0.flac",
+                "name": "Jalmaan - Airtime Junkies"
+            }
+        ]
+    },
+    "strings": {
+        "name": {
+            "en-GB": "Acid style"
+        }
+    }
+}


### PR DESCRIPTION
This PR adds music that will be part of the `openrct.music.alternative` asset pack, as placeholder for Techno style if RCT2 isn't loaded in. 

This is fresh from the press, made over the past week orso. I think it's finished but if you notice anything off about it please let me know and ill make sure to change it. The feedback is always welcome!

Feel free to try it out as parkobj: https://cdn.discordapp.com/attachments/694586451500859469/976113292521123970/openrct2.music.acid.parkobj

You can listen to the tune here: https://soundcloud.com/jalmaan/airtime-junkies/s-K7SoeET4cqL